### PR TITLE
Fix nginx config

### DIFF
--- a/examples/labean.nginx.ex
+++ b/examples/labean.nginx.ex
@@ -11,7 +11,7 @@ server {
     auth_basic      "Administrator Login";
     auth_basic_user_file  /var/www/.htpasswd;
     proxy_set_header  X-Real-IP  $remote_addr;
-    proxy_pass http://127.0.0.1:8080/$1;
+    proxy_pass http://127.0.0.1:8080/secret/$1;
   }
 }
                                   


### PR DESCRIPTION
nginx takes only task name as $1 without prefix. labean see this request url as `Bad request: '/vpn/': No such task`
Adding prefix to proxy_pass fixed this, labean see this request as `URL Path:  /secret/vpn/off` and processes it correctly

nginx version: nginx/1.18.0